### PR TITLE
fixing PropTypes import

### DIFF
--- a/HideableView.js
+++ b/HideableView.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import { PropTypes } from 'prop-types';
 import { Animated  } from 'react-native';
 
 class HideableView extends Component {


### PR DESCRIPTION
Previously, PropTypes imported from 'react' module. Now moved in 'prop-type'.  As the docs here (https://facebook.github.io/react/docs/typechecking-with-proptypes.html) said :

> React.PropTypes has moved into a different package since React v15.5. Please use the prop-types library instead.
